### PR TITLE
fix: read-only-columns

### DIFF
--- a/src/components/m-table-edit-row.js
+++ b/src/components/m-table-edit-row.js
@@ -44,12 +44,12 @@ export default class MTableEditRow extends React.Component {
             allowEditing = columnDef.editable(columnDef, this.props.data);
         }
         if (!columnDef.field || !allowEditing) {
-          const readonlyValue = this.props.getFieldValue(this.state.data, columnDef);
+          //const readonlyValue = this.props.getFieldValue(this.state.data, columnDef);
           return (
             <this.props.components.Cell
               icons={this.props.icons}
               columnDef={columnDef}
-              value={readonlyValue}
+              value={value}
               key={columnDef.tableData.id}
               rowData={this.props.data}
             />


### PR DESCRIPTION
- Not allowing edit on a column crashes the web page
- Showed getFieldValue is null error